### PR TITLE
Fixed PreferenceDialog close on orientation change

### DIFF
--- a/QuickLyric/src/main/AndroidManifest.xml
+++ b/QuickLyric/src/main/AndroidManifest.xml
@@ -108,6 +108,7 @@
             android:label="@string/settings_title"
             android:launchMode="singleTop"
             android:parentActivityName=".MainActivity"
+            android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="stateUnchanged|adjustPan">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"


### PR DESCRIPTION
Fixed PreferenceDialog close on orientation change by ignoring configChanges in SettingsActivity. (Fix for issue #149)