### PR TITLE
Show song track title in notification title when available

### DIFF
--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/WearableRequestReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/WearableRequestReceiver.java
@@ -87,8 +87,8 @@ public class WearableRequestReceiver extends BroadcastReceiver implements Lyrics
         mContext.setTheme(themes[themeNum]);
 
         notifBuilder.setSmallIcon(R.drawable.ic_notif)
-                .setContentTitle(mContext.getString(R.string.app_name))
-                .setContentText(String.format("%s - %s", lyrics.getArtist(), lyrics.getTitle()))
+                .setContentTitle(lyrics.getTitle())
+                .setContentText(lyrics.getArtist())
                 .setStyle(bigStyle)
                 .setGroup("Lyrics_Notification")
                 .setOngoing(false)

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/utils/NotificationUtil.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/utils/NotificationUtil.java
@@ -90,8 +90,8 @@ public class NotificationUtil {
         context.setTheme(themes[themeNum]);
 
         notifBuilder.setSmallIcon(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? R.drawable.ic_notif : R.drawable.ic_notif4)
-                .setContentTitle(context.getString(R.string.app_name))
-                .setContentText(String.format("%s - %s", artist, track))
+                .setContentTitle(track)
+                .setContentText(artist)
                 .setContentIntent(prefOverlay ? overlayPending : openAppPending)
                 .setVisibility(-1) // Notification.VISIBILITY_SECRET
                 .setGroup("Lyrics_Notification")
@@ -100,8 +100,8 @@ public class NotificationUtil {
                 .setGroupSummary(true);
 
         wearableNotifBuilder.setSmallIcon(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? R.drawable.ic_notif : R.drawable.ic_notif4)
-                .setContentTitle(context.getString(R.string.app_name))
-                .setContentText(String.format("%s - %s", artist, track))
+                .setContentTitle(track)
+                .setContentText(artist)
                 .setContentIntent(openAppPending)
                 .setVisibility(-1) // Notification.VISIBILITY_SECRET
                 .setGroup("Lyrics_Notification")


### PR DESCRIPTION
On (at least Android 8 and 9), the app's name is always on the notifications they are displaying. This makes setting the notification title to the app name redundant. In the case of "minimized" notifications, this means the current notification gives no helpful information until expanded (displays "QuickLyric * QuickLyric")

This change changes the notifications (for both phones and wearables) that relate to music playing to have a title that is the current playing track (as far as QuickLyric assumes).

If the song title is very long (e.g. "Our Lawyer Made Us Change The Name Of This Song So We Wouldn't Get Sued"), it'll just truncate as it would any way in the fully expanded notification.

Let me know if this seems like a positive change to you or if there's something else I could do to make it better. I did not test on WearOS but can only imagine it works the same.